### PR TITLE
feat: add ExtraFields to Issue struct [LK-2155]

### DIFF
--- a/result.go
+++ b/result.go
@@ -2,6 +2,7 @@ package codacytool
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/sirupsen/logrus"
 )
@@ -26,6 +27,9 @@ type Issue struct {
 }
 
 func (i Issue) ToJSON() ([]byte, error) {
+	if len(i.ExtraFields) > 0 && !json.Valid(i.ExtraFields) {
+		return nil, errors.New("invalid JSON in ExtraFields")
+	}
 	return json.Marshal(i)
 }
 func (i Issue) GetFile() string {

--- a/result.go
+++ b/result.go
@@ -16,12 +16,13 @@ type Result interface {
 
 // Issue is the output for each issue found by the tool.
 type Issue struct {
-	PatternID  string `json:"patternId"`
-	File       string `json:"filename"`
-	Line       int    `json:"line"`
-	Message    string `json:"message"`
-	Suggestion string `json:"suggestion,omitempty"`
-	SourceID   string `json:"sourceId,omitempty"`
+	PatternID   string          `json:"patternId"`
+	File        string          `json:"filename"`
+	Line        int             `json:"line"`
+	Message     string          `json:"message"`
+	Suggestion  string          `json:"suggestion,omitempty"`
+	SourceID    string          `json:"sourceId,omitempty"`
+	ExtraFields json.RawMessage `json:"extraFields,omitempty"`
 }
 
 func (i Issue) ToJSON() ([]byte, error) {

--- a/result_test.go
+++ b/result_test.go
@@ -1,6 +1,7 @@
 package codacytool
 
 import (
+	"encoding/json"
 	"sort"
 	"testing"
 
@@ -62,6 +63,21 @@ func TestResultsGetFile(t *testing.T) {
 	assert.Equal(t, "issue-file", issueFile)
 	assert.Equal(t, "file-error", fileErrorFile)
 	assert.Empty(t, sbomFile)
+}
+
+func TestIssueExtraFieldsOmittedWhenNil(t *testing.T) {
+	issue := Issue{PatternID: "p", File: "f", Line: 1, Message: "m"}
+	b, err := issue.ToJSON()
+	assert.NoError(t, err)
+	assert.NotContains(t, string(b), "extraFields")
+}
+
+func TestIssueExtraFieldsSerializedWhenSet(t *testing.T) {
+	extra := json.RawMessage(`{"dependenciesChains":[["root","vuln"]],"CVE":"CVE-2024-1234","fixVersion":"1.2.3"}`)
+	issue := Issue{PatternID: "p", File: "f", Line: 1, Message: "m", ExtraFields: extra}
+	b, err := issue.ToJSON()
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{"patternId":"p","filename":"f","line":1,"message":"m","extraFields":{"dependenciesChains":[["root","vuln"]],"CVE":"CVE-2024-1234","fixVersion":"1.2.3"}}`, string(b))
 }
 
 type BadResult struct{}

--- a/result_test.go
+++ b/result_test.go
@@ -80,6 +80,13 @@ func TestIssueExtraFieldsSerializedWhenSet(t *testing.T) {
 	assert.JSONEq(t, `{"patternId":"p","filename":"f","line":1,"message":"m","extraFields":{"dependenciesChains":[["root","vuln"]],"CVE":"CVE-2024-1234","fixVersion":"1.2.3"}}`, string(b))
 }
 
+func TestIssueExtraFieldsInvalidJSONReturnsError(t *testing.T) {
+	extra := json.RawMessage(`{"invalid":`)
+	issue := Issue{PatternID: "p", File: "f", Line: 1, Message: "m", ExtraFields: extra}
+	_, err := issue.ToJSON()
+	assert.Error(t, err)
+}
+
 type BadResult struct{}
 
 func (r BadResult) ToJSON() ([]byte, error) {


### PR DESCRIPTION
## Summary

- Adds `ExtraFields json.RawMessage` field to `Issue` struct
- `omitempty` ensures full backward compatibility — existing tools emit no field, consumers receive `nil`
- Enables tools (initially codacy-trivy) to emit structured metadata such as dependency chains, CVE IDs, and fix versions without changing the shared interface

## Part of

Dependency chain propagation initiative — this is **TASK 1** of the SRM dependency chains plan.

Downstream: `codacy-trivy` will bump to this version to populate `ExtraFields["dependenciesChains"]`.

## Test plan

- [x] `TestIssueExtraFieldsOmittedWhenNil` — verifies `extraFields` absent when nil
- [x] `TestIssueExtraFieldsSerializedWhenSet` — verifies full JSON round-trip with nested array structure
- [x] Existing `TestResultsToJSON` unchanged and passing

After merge: tag `v8.1.0` to publish new minor version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)